### PR TITLE
Update default configuration

### DIFF
--- a/src/gatling/resources/conf/application.conf
+++ b/src/gatling/resources/conf/application.conf
@@ -1,15 +1,19 @@
 baseUrl = "http://localhost:8485"
 baseUrl = ${?BASE_URL}
 
-s2sUrl = "http://localhost:8080"
+s2sUrl = "http://localhost:8489"
 s2sUrl = ${?S2S_URL}
 
 service {
+  name = "divorce"
   name = ${?SERVICE_NAME}
+
+  pass = "AAAAAAAAAAAAAAAA"
   pass = ${?SERVICE_PASS}
 }
 
 proxy {
+  host = ""
   host = ${?PROXY_HOST}
   port = ${?PROXY_PORT}
 }


### PR DESCRIPTION
- opensourced s2s runs on port 8489, not 8080
- use s2s's sample service
- avoid `No configuration setting found for key ‘proxy.host’` error 