### PR TITLE
Removed retired artifactory from plugin management

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,5 @@
 pluginManagement {
   repositories {
-    maven {
-      url 'https://artifactory.reform.hmcts.net/artifactory/libs-release'
-    }
     gradlePluginPortal()
   }
 }


### PR DESCRIPTION

### Change description ###

- Nightly pipeline tests are failing with below error
```
03:59:47  - Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
03:59:47  - Plugin Repositories (could not resolve plugin artifact 'com.github.lkishalmi.gatling:com.github.lkishalmi.gatling.gradle.plugin:3.0.2')
03:59:47    Searched in the following repositories:
03:59:47      maven(https://artifactory.reform.hmcts.net/artifactory/libs-release)
03:59:47      Gradle Central Plugin Repository
03:59:47      maven2(https://artifactory.platform.hmcts.net/artifactory/maven-remotes)
03:59:47 

```

- Removed retired artifactory repo URL

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```