### PR TITLE
Remove deprecated method

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -17,7 +17,6 @@ withNightlyPipeline('java', 'rpe', 'send-letter') {
   env.S2S_URL = 'https://rpe-service-auth-provider-perftest.service.core-compute-perftest.internal'
   env.SERVICE_NAME = 'send_letter_tests'
 
-  setVaultName("rpe-send-letter")
   loadVaultSecrets([
     's2s-#{env}': [
       $class     : 'AzureKeyVaultSecret',

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -19,11 +19,13 @@ withNightlyPipeline('java', 'rpe', 'send-letter') {
 
   loadVaultSecrets([
     's2s-#{env}': [
-      $class     : 'AzureKeyVaultSecret',
-      secretType : 'Secret',
-      name       : 'test-s2s-secret',
-      version    : '',
-      envVariable: 'SERVICE_PASS'
+      [
+        $class     : 'AzureKeyVaultSecret',
+        secretType : 'Secret',
+        name       : 'test-s2s-secret',
+        version    : '',
+        envVariable: 'SERVICE_PASS'
+      ]
     ]
   ])
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Update Jenkinsfiles to solve deprecated vault sets](https://tools.hmcts.net/jira/browse/BPS-775)

### Change description ###

Function `setVaultName` call was hiding among those settings. Removed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
